### PR TITLE
feat(Stock): Codex 사용 중 잘못 사용하여 PR

### DIFF
--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/dto/CandleDto.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/dto/CandleDto.java
@@ -16,7 +16,7 @@ public class CandleDto {
 
     public static CandleDto toDto(Candle candle) {
         return CandleDto.builder()
-                .time(candle.getTimeSec())
+                .time(candle.getTimeEpochSec())
                 .open(candle.getOpenPrice())
                 .high(candle.getHighPrice())
                 .low(candle.getLowPrice())

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/entity/Candle.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/entity/Candle.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name="tbl_candle")
+@Table(name = "candle")
 @Getter
 @Builder
 @AllArgsConstructor
@@ -18,28 +18,27 @@ public class Candle {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long candleId;
 
-    // FK
-    @Column(nullable=false)
+    @Column(name = "stock_id", nullable = false)
     private Long stockId;
 
     // lightweight-charts: epoch seconds
-    @Column(nullable = false)
-    private Long timeSec;
+    @Column(name = "time_epoch_sec", nullable = false)
+    private Long timeEpochSec;
 
     // 예: "1"(1m), "5"(5m), "D"(day) 등
     @Column(nullable = false, length = 10)
     private String resolution;
 
-    @Column(nullable = false)
+    @Column(name = "open_price", nullable = false)
     private Double openPrice;
 
-    @Column(nullable = false)
+    @Column(name = "high_price", nullable = false)
     private Double highPrice;
 
-    @Column(nullable = false)
+    @Column(name = "low_price", nullable = false)
     private Double lowPrice;
 
-    @Column(nullable = false)
+    @Column(name = "close_price", nullable = false)
     private Double closePrice;
 
     @Column(nullable = false)
@@ -47,7 +46,7 @@ public class Candle {
 
     public static Candle create(
             Long stockId,
-            Long timeSec,
+            Long timeEpochSec,
             String resolution,
             Double openPrice,
             Double highPrice,
@@ -57,7 +56,7 @@ public class Candle {
     ) {
         Candle candle = new Candle();
         candle.stockId = stockId;
-        candle.timeSec = timeSec;
+        candle.timeEpochSec = timeEpochSec;
         candle.resolution = resolution;
         candle.openPrice = openPrice;
         candle.highPrice = highPrice;

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/repository/CandleRepository.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/repository/CandleRepository.java
@@ -4,15 +4,18 @@ import com.ambiguous.buyornot.charts.entity.Candle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CandleRepository extends JpaRepository<Candle, Long> {
 
-    List<Candle> findByStockIdAndResolutionAndTimeSecBetweenOrderByTimeSecAsc(
+    List<Candle> findByStockIdAndResolutionAndTimeEpochSecBetweenOrderByTimeEpochSecAsc(
             Long stockId,
             String resolution,
             long from,
             long to
     );
+
+    Optional<Candle> findTopByStockIdAndResolutionOrderByTimeEpochSecDesc(Long stockId, String resolution);
 
     boolean existsByStockIdAndResolution(Long stockId, String resolution);
 }

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/service/ChartService.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/charts/service/ChartService.java
@@ -36,7 +36,7 @@ public class ChartService {
 
         List<CandleDto> candles =
                 candleRepository
-                        .findByStockIdAndResolutionAndTimeSecBetweenOrderByTimeSecAsc(
+                        .findByStockIdAndResolutionAndTimeEpochSecBetweenOrderByTimeEpochSecAsc(
                                 stockId, res, f, t
                         )
                         .stream()
@@ -51,24 +51,14 @@ public class ChartService {
                                 .candles(candles).build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public CandleDto latestBar(Long stockId, String resolution) {
         String res = normalizeResolution(resolution);
-        long now = Instant.now().getEpochSecond();
 
-        double open = 100 + Math.random() * 10;
-        double close = open + (Math.random() - 0.5);
-        double high = Math.max(open, close);
-        double low = Math.min(open, close);
-        double volume = 50 + Math.random() * 200;
+        Candle candle = candleRepository
+                .findTopByStockIdAndResolutionOrderByTimeEpochSecDesc(stockId, res)
+                .orElseThrow(() -> new IllegalArgumentException("해당 종목의 캔들 데이터가 존재하지 않습니다."));
 
-        // ChartService.java
-        Candle candle = Candle.create(
-                stockId, now, res,
-                open, high, low, close, volume
-        );
-
-        candleRepository.save(candle);
         return toDto(candle);
     }
 

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/stock/entity/Stock.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/stock/entity/Stock.java
@@ -6,9 +6,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.cglib.core.Local;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -26,6 +23,9 @@ public class Stock extends BaseEntity {
     // KRX, NASDAK
     @Column(nullable = false, length = 20)
     private String exchange;
+
+    @Column(nullable = false)
+    private boolean active = true;
 
     public void update(String name, String exchange) {
         this.name = name;


### PR DESCRIPTION
## Summary
- align candle entity mappings with the collector server schema and column names
- serve latest candle data from stored records instead of generating synthetic candles
- add an `active` flag to stocks so collectors can filter enabled symbols consistently

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a00b79c748321868efa5da1ecbf8e)