### PR TITLE
feat(hotposting): 핫게시글 정리/삭제 서비스 구현

### DIFF
--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/common/support/error/ErrorCode.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/common/support/error/ErrorCode.java
@@ -8,5 +8,15 @@ public enum ErrorCode {
 
     // 유효하지 않은 인자값
     E400,   // 경고
-    E401,    // 에러
+    E401,   // 에러
+
+    // HotPosting - 4xx
+    H400,
+    H401,
+    H403,
+    H404,
+    H409,
+
+    // HotPosting - 5xx
+    H500
 }

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/common/support/error/ErrorType.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/common/support/error/ErrorType.java
@@ -13,8 +13,38 @@ public enum ErrorType {
 
     // 유효하지 않은 인자값 경고
     DEFAULT_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, ErrorCode.E400, "An unexpected error has occurred.", LogLevel.WARN),
-    DEFAULT_ARGUMENT_NOT_VALID_ISNULL(HttpStatus.BAD_REQUEST, ErrorCode.E401, "유효하지 않은 값입니다.", LogLevel.ERROR)
+    DEFAULT_ARGUMENT_NOT_VALID_ISNULL(HttpStatus.BAD_REQUEST, ErrorCode.E401, "유효하지 않은 값입니다.", LogLevel.ERROR),
 
+    // 핫포스팅
+    // HotPosting - 4xx
+    HOTPOSTING_POST_NOT_FOUND(
+            HttpStatus.NOT_FOUND, ErrorCode.H404,
+            "존재하지 않는 게시글입니다.", LogLevel.WARN),
+
+    HOTPOSTING_STOCK_NOT_FOUND(
+            HttpStatus.NOT_FOUND, ErrorCode.H404,
+            "존재하지 않는 종목입니다.", LogLevel.WARN),
+
+    HOTPOSTING_NOT_FOUND(
+            HttpStatus.NOT_FOUND, ErrorCode.H404,
+            "핫게시글로 등록되지 않은 게시글입니다.", LogLevel.WARN),
+
+    HOTPOSTING_ALREADY_EXISTS(
+            HttpStatus.CONFLICT, ErrorCode.H409,
+            "이미 핫게시글로 등록된 게시글입니다.", LogLevel.WARN),
+
+    HOTPOSTING_FORBIDDEN(
+            HttpStatus.FORBIDDEN, ErrorCode.H403,
+            "관리자만 접근할 수 있습니다.", LogLevel.WARN),
+
+    HOTPOSTING_INVALID_REQUEST(
+            HttpStatus.BAD_REQUEST, ErrorCode.H400,
+            "요청 값이 올바르지 않습니다.", LogLevel.WARN),
+
+    // HotPosting - 5xx
+    HOTPOSTING_REDIS_SYNC_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.H500,
+            "Redis 반영에 실패했습니다.", LogLevel.ERROR)
 
     ;
 

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/HotPostingController.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/HotPostingController.java
@@ -27,5 +27,11 @@ public class HotPostingController {
         return ApiResult.success();
     }
 
+    @DeleteMapping
+    public ApiResult<?> delete(@RequestBody HotPostingPassiveRequest request){
+        hotPostingService.removeByAdmin(request);
+        return ApiResult.success();
+    }
+
 
 }

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/redis/HotPostingRedisStore.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/redis/HotPostingRedisStore.java
@@ -32,7 +32,7 @@ public class HotPostingRedisStore {
 
     }
 
-    // 핫포스팅 스케줄러에서 게시글이 존재하는지 확인하는 메서드에서 사용 예정
+    // 핫포스팅 만료시간이 지난 게시글 redis에서 지울때 사용
     public void remove(Long postingId, Long stockId){
         String key = AmbiguousKey.hotPostingTop30(stockId);
         redisTemplate.opsForZSet().remove(key, postingId.toString());

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/scheduler/HotPostingScheduler.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/scheduler/HotPostingScheduler.java
@@ -17,39 +17,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HotPostingScheduler {
 
-    private final PostRepository postRepository;
     private final HotPostingService hotPostingService;
-    private final HotPostingRepository hotPostingRepository;
-    private final HotPostingRedisStore hotPostingRedisStore;
+
 
     @Scheduled(fixedRate = 60000)
     public void hotPostingRegister(){
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime oneHourAgo = now.minusHours(1);
-
-        for(Post p : postRepository.findByCreatedAtAfter(oneHourAgo)){
-            int like = postRepository.findLikeCount(p.getId());
-
-            if(like >= 10){
-                hotPostingService.registerFromPost(p);
-            }
-        }
+        hotPostingService.autoRegisterHotPostings();
 
     }
 
     @Scheduled(fixedRate = 5*60*1000)
     public void cleanupExpiredFromRedis(){
-        LocalDateTime now = LocalDateTime.now();
-        // 만료되었지만 Redis에 올라간 상태인 핫포스팅 찾기
-        List<HotPosting> expired = hotPostingRepository.findByExpireAtBeforeAndRedisSyncedTrue(now);
 
-        for (HotPosting hotPosting : expired){
-            // Redis에서 제거
-            hotPostingRedisStore.remove(hotPosting.getPostingId(), hotPosting.getStockId());
-
-            // 핫포스팅 DB에 Redis에서 삭제되었다는 표시
-            hotPosting.markRedisUnsynced();
-        }
+        hotPostingService.cleanupExpiredFromRedis();
 
     }
 

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/scheduler/HotPostingScheduler.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/controller/scheduler/HotPostingScheduler.java
@@ -1,5 +1,6 @@
 package com.ambiguous.buyornot.hotposting.api.controller.scheduler;
 
+import com.ambiguous.buyornot.hotposting.api.controller.redis.HotPostingRedisStore;
 import com.ambiguous.buyornot.hotposting.api.domain.HotPosting;
 import com.ambiguous.buyornot.hotposting.api.domain.HotPostingService;
 import com.ambiguous.buyornot.hotposting.api.storage.HotPostingRepository;
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -18,6 +20,7 @@ public class HotPostingScheduler {
     private final PostRepository postRepository;
     private final HotPostingService hotPostingService;
     private final HotPostingRepository hotPostingRepository;
+    private final HotPostingRedisStore hotPostingRedisStore;
 
     @Scheduled(fixedRate = 60000)
     public void hotPostingRegister(){
@@ -30,6 +33,22 @@ public class HotPostingScheduler {
             if(like >= 10){
                 hotPostingService.registerFromPost(p);
             }
+        }
+
+    }
+
+    @Scheduled(fixedRate = 5*60*1000)
+    public void cleanupExpiredFromRedis(){
+        LocalDateTime now = LocalDateTime.now();
+        // 만료되었지만 Redis에 올라간 상태인 핫포스팅 찾기
+        List<HotPosting> expired = hotPostingRepository.findByExpireAtBeforeAndRedisSyncedTrue(now);
+
+        for (HotPosting hotPosting : expired){
+            // Redis에서 제거
+            hotPostingRedisStore.remove(hotPosting.getPostingId(), hotPosting.getStockId());
+
+            // 핫포스팅 DB에 Redis에서 삭제되었다는 표시
+            hotPosting.markRedisUnsynced();
         }
 
     }

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/domain/HotPosting.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/domain/HotPosting.java
@@ -18,9 +18,6 @@ public class HotPosting extends BaseEntity {
     @Column(name = "posting_id", nullable = false, unique = true)
     private Long postingId; // 게시글 아이디 - 게시글 테이블
 
-    @Column(name = "writer_id", nullable = false)
-    private Long writerId;  // 게시글 작성자 아이디 - 게시글 테이블(사용자 테이블)
-
     @Column(name = "stock_id", nullable = false, length = 20)
     private Long stockId;  // 종목 종류
 
@@ -41,12 +38,11 @@ public class HotPosting extends BaseEntity {
     @Column(name = "redis_synced_at")
     private LocalDateTime redisSyncedAt;
 
-    public HotPosting(Long postingId, Long writerId, Long stockId,
+    public HotPosting(Long postingId,Long stockId,
                       LocalDateTime writeAt,
                       LocalDateTime registeredAt,
                       LocalDateTime expireAt) {
         this.postingId = postingId;
-        this.writerId = writerId;
         this.stockId = stockId;
         this.writeAt = writeAt;
         this.registeredAt = registeredAt;

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/domain/HotPostingService.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/domain/HotPostingService.java
@@ -1,5 +1,7 @@
 package com.ambiguous.buyornot.hotposting.api.domain;
 
+import com.ambiguous.buyornot.common.support.error.CoreException;
+import com.ambiguous.buyornot.common.support.error.ErrorType;
 import com.ambiguous.buyornot.hotposting.api.controller.redis.HotPostingRedisStore;
 import com.ambiguous.buyornot.hotposting.api.controller.request.HotPostingPassiveRequest;
 import com.ambiguous.buyornot.hotposting.api.storage.HotPostingRepository;
@@ -7,37 +9,41 @@ import com.ambiguous.buyornot.posting.api.domain.Post;
 import com.ambiguous.buyornot.posting.storage.PostRepository;
 import com.ambiguous.buyornot.stock.storage.StockRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class HotPostingService {
 
-    private HotPostingRepository hotPostingRepository;
-    private StockRepository stockRepository;
-    private HotPostingRedisStore hotPostingRedisStore;
-    private PostRepository postRepository;
+    private final HotPostingRepository hotPostingRepository;
+    private final StockRepository stockRepository;
+    private final HotPostingRedisStore hotPostingRedisStore;
+    private final PostRepository postRepository;
 
+    // 관리자용 등록
     @Transactional
     public void register(HotPostingPassiveRequest request){
         // 존재하는 게시글인지 검증
         Post post = postRepository.findById(request.postingId())
-                .orElseThrow(() -> new IllegalArgumentException("Posting with id " + request.postingId() + " does not exist"));
+                .orElseThrow(() -> new CoreException(ErrorType.HOTPOSTING_POST_NOT_FOUND));
 
         Long postId = post.getId();
         // 핫게시글에 이미 등록된 게시글인지 검증
         if(hotPostingRepository.existsByPostingId(postId)){
-            throw new IllegalStateException("이미 핫게시글로 등록된 게시글입니다.");
+            throw new CoreException(ErrorType.HOTPOSTING_ALREADY_EXISTS);
         }
         LocalDateTime now = LocalDateTime.now();
         Long stockId = post.getStockId();
 
         // 존재하는 종목인지 검증
-        if(stockRepository.existsById(stockId)){
-            throw new IllegalStateException("존재하지 않는 종목입니다.");
+        if(!stockRepository.existsById(stockId)){
+            throw new CoreException(ErrorType.HOTPOSTING_STOCK_NOT_FOUND);
         }
 
         HotPosting hotPosting = new HotPosting(
@@ -48,12 +54,34 @@ public class HotPostingService {
                 post.getCreatedAt().plusHours(72)
         );
 
-        LocalDateTime registeredAt = hotPosting.getCreatedAt();
+        LocalDateTime registeredAt = now;
 
         hotPostingRepository.save(hotPosting);
-        hotPostingRedisStore.add(postId,stockId,registeredAt);
-        hotPosting.markRedisSynced(registeredAt);
+        // Redis 반영 (실패하면 에러)
+        try {
+            hotPostingRedisStore.add(postId, stockId, registeredAt);
+            hotPosting.markRedisSynced(registeredAt);
+        } catch (Exception e) {
+            throw new CoreException(ErrorType.HOTPOSTING_REDIS_SYNC_FAILED);
+        }
 
+    }
+
+    // 관리자가 삭제 (hard delete)
+    @Transactional
+    public void removeByAdmin(HotPostingPassiveRequest request){
+        Long postId = request.postingId();
+
+        // 존재하는 게시글인지 검증
+        postRepository.findById(postId)
+                .orElseThrow(() -> new CoreException(ErrorType.HOTPOSTING_POST_NOT_FOUND));;
+
+        // 핫포스팅에 등록된 게시글인지 검증
+        HotPosting hp = hotPostingRepository.findByPostingId(postId)
+                .orElseThrow(() -> new CoreException(ErrorType.HOTPOSTING_NOT_FOUND));;
+
+        hotPostingRedisStore.remove(hp.getPostingId(), hp.getStockId());
+        hotPostingRepository.delete(hp);
     }
 
     // 자동 등록 서비스
@@ -66,8 +94,8 @@ public class HotPostingService {
         Long stockId = post.getStockId();
         // stockId가 잘못되었을 경우
         // 존재하는 종목인지 검증
-        if(stockRepository.existsById(stockId)){
-            throw new IllegalStateException("존재하지 않는 종목입니다.");
+        if(!stockRepository.existsById(stockId)){
+            throw new CoreException(ErrorType.HOTPOSTING_STOCK_NOT_FOUND);
         }
 
         HotPosting hotPosting = new HotPosting(
@@ -79,15 +107,19 @@ public class HotPostingService {
 
         );
 
-        LocalDateTime registeredAt = hotPosting.getCreatedAt();
+        LocalDateTime registeredAt = now;
 
         hotPostingRepository.save(hotPosting);
 
-        // DB 저장 성공 후 Redis 반영
-        hotPostingRedisStore.add(postId,stockId,registeredAt);
 
-        // ✅ Redis 반영 성공 기록
-        hotPosting.markRedisSynced(registeredAt);
+        try {
+            hotPostingRedisStore.add(postId, stockId, registeredAt);
+            hotPosting.markRedisSynced(registeredAt);
+        } catch (Exception e) {
+            // 자동 등록은 실패해도 다음 작업 계속
+            // redisSynced는 기본 false니까 그대로 둠
+            log.warn("Redis sync failed for postId={}", postId, e);
+        }
     }
 
     // posting delete 서비스에서 호출이 필요함 (hard delete)
@@ -102,20 +134,34 @@ public class HotPostingService {
         hotPostingRepository.delete(hp);
     }
 
-    // 관리자가 삭제 (hard delete)
+    // 스케줄러
+
     @Transactional
-    public void removeByAdmin(HotPostingPassiveRequest request){
-        Long postId = request.postingId();
+    public void autoRegisterHotPostings() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneHourAgo = now.minusHours(1);
 
-        // 존재하는 게시글인지 검증
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("Posting with id " + postId + " does not exist"));
+        List<Post> recentPosts = postRepository.findByCreatedAtAfter(oneHourAgo);
 
-        HotPosting hp = hotPostingRepository.findByPostingId(postId)
-                .orElseThrow(() -> new IllegalArgumentException("Posting with id " + postId + " does not exist"));
+        for (Post p : recentPosts) {
+            int like = postRepository.findLikeCount(p.getId());
+            if (like >= 10) {
+                registerFromPost(p); // 네가 이미 만든 메서드 재사용
+            }
+        }
+    }
 
-        hotPostingRedisStore.remove(hp.getPostingId(), hp.getStockId());
-        hotPostingRepository.delete(hp);
+    @Transactional
+    public void cleanupExpiredFromRedis() {
+        LocalDateTime now = LocalDateTime.now();
+
+        List<HotPosting> expired =
+                hotPostingRepository.findByExpireAtBeforeAndRedisSyncedTrue(now);
+
+        for (HotPosting hotPosting : expired) {
+            hotPostingRedisStore.remove(hotPosting.getPostingId(), hotPosting.getStockId());
+            hotPosting.markRedisUnsynced();
+        }
     }
 
 }

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/storage/HotPostingRepository.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/storage/HotPostingRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface HotPostingRepository extends JpaRepository<HotPosting, Long> {
 
@@ -15,4 +16,5 @@ public interface HotPostingRepository extends JpaRepository<HotPosting, Long> {
     List<HotPosting> findByExpireAtBeforeAndRedisSyncedTrue(LocalDateTime now);
 
 
+    Optional<HotPosting> findByPostingId(Long postId);
 }

--- a/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/storage/HotPostingRepository.java
+++ b/BuyOrNot/src/main/java/com/ambiguous/buyornot/hotposting/api/storage/HotPostingRepository.java
@@ -10,6 +10,9 @@ public interface HotPostingRepository extends JpaRepository<HotPosting, Long> {
 
     boolean existsByPostingId(Long postingId);
 
+    // 만료됐고 아직 Redis에 남아있을 가능성이 있는 대상만 뽑기
+    // 추후 데이터가 많아질 경우 page로 수정
+    List<HotPosting> findByExpireAtBeforeAndRedisSyncedTrue(LocalDateTime now);
 
 
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- Closes #106 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- [x] 만료 시간이 지난 글 레디스에서 삭제하는 기능 (scheduler)
- [x] hotposting 엔티티 symbol => stockId로 수정, writedId 삭제
- [x] 포스팅에서 삭제 시 핫포스팅 동기화를 위한 메서드 구현
- [x] 관리자 운영용 삭제 api

## ✅ 테스트 결과
> 수행한 테스트와 결과를 요약해주세요. (예: 단위 테스트 전체 통과)
- [ ] 단위 테스트 (JUnit)
- [ ] 통합 테스트

## 💬 리뷰 요구사항
- 좋아요 수가 10에서 줄어들 경우 redis에서 빼는 로직은 서버 과부하를 고려해 일단 구현하지 않았습니다.
- 관리자 운영용 삭제 api에 필터처리 필요합니다.
- post delete 서비스에서 호출하는 로직 추가 필요합니다.  => 담당자 추후 추가 또는 rebase

---
### ✅ 변경 사항 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했나요?
- [x] 불필요한 공백이나 주석을 제거했나요?
- [ ] 코드에 영향이 있는 부분에 대해 테스트를 작성했나요?
- [ ] 모든 테스트가 성공했나요?
